### PR TITLE
Extend report object

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ var API_URL = 'http://goodtables.okfnlabs.org/api/';
 
 
 function ValidationReport(report, options) {
+  this.rawResults = report.results;
+  this.headers = report.meta.headers;
+
   if(options.isGrouped)
     // Grouped report structure
     this.errors = _.reduce(report.results, function(R, V) {
@@ -20,8 +23,10 @@ function ValidationReport(report, options) {
   return this;
 }
 
-ValidationReport.prototype.isValid = function() { return !Boolean(this.errors.length); }
+ValidationReport.prototype.getHeaders = function() { return this.headers; }
+ValidationReport.prototype.getSortedByRows = function() { return this.rawResults; }
 ValidationReport.prototype.getValidationErrors = function() { return this.errors; }
+ValidationReport.prototype.isValid = function() { return !Boolean(this.errors.length); }
 
 module.exports = function(options) {
   // Provide default values for most params

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function ValidationReport(report, options) {
 }
 
 ValidationReport.prototype.getHeaders = function() { return this.headers; }
-ValidationReport.prototype.getSortedByRows = function() { return this.rawResults; }
+ValidationReport.prototype.getGroupedByRows = function() { return this.rawResults; }
 ValidationReport.prototype.getValidationErrors = function() { return this.errors; }
 ValidationReport.prototype.isValid = function() { return !Boolean(this.errors.length); }
 


### PR DESCRIPTION
Extend report object with some properties required for https://github.com/okfn/datapackagist/issues/45, like headers list and results which are grouped by row.
