### PR TITLE
Allow user passing custom endpoint URL. Closes #1.

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ ValidationReport.prototype.getGroupedByRows = function() { return this.rawResult
 ValidationReport.prototype.getValidationErrors = function() { return this.errors; }
 ValidationReport.prototype.isValid = function() { return !Boolean(this.errors.length); }
 
-module.exports = function(options) {
+module.exports = function(options, userEndpointURL) {
   // Provide default values for most params
   this.options = _.extend({
     fail_fast        : true,
@@ -49,7 +49,7 @@ module.exports = function(options) {
       throw new Error('You need to provide data file to validate');
 
     return new Promise((function(RS, RJ) {
-      request[this.options.method](API_URL + 'run')
+      request[this.options.method](userEndpointURL || API_URL + 'run')
         // Provide request data with .query() in case of GET, otherwise use .send()
         [this.options.method == 'get' ? 'query' : 'send'](_.extend(
           _.omit(this.options, 'method'),


### PR DESCRIPTION
Custom params and endpoint URL should be passed like this

``` javascript
new GoodTables(<options object>, <ednpoint URL>);
```
- Any param from `<options object>` except `method` will be passed to the endpoint URL, so it looks like there is no need in special config for custom URL params
- added endpoint optional param which will be used for request as is 
